### PR TITLE
Use for instead of forEach and reset array instead of allocating new

### DIFF
--- a/lib/queueMicrotask.mjs
+++ b/lib/queueMicrotask.mjs
@@ -31,7 +31,8 @@ const createQueueMicrotaskViaMutationObserver = () => {
   let microtaskQueue = [];
   const observer = new MutationObserver(() => {
     microtaskQueue.forEach((microtask) => microtask());
-    microtaskQueue = [];
+    for (let x = 0; x < microtaskQueue.length; ++x) microtaskQueue[x]();
+    microtaskQueue.length = 0;
   });
   const node = document.createTextNode('');
   observer.observe(node, {characterData: true});


### PR DESCRIPTION
This makes everything a little faster in benchmarks, however it uses more bytes.